### PR TITLE
fix: cross platform usage `npx rimraf docs`

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-
+    if: github.repository != 'LACMTA/11ty-web-template'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -23,7 +23,13 @@ jobs:
         cache: 'npm'
     - name: Build Site
       run: npm run clean:build
-    - name: Copy CNAME to docs/
+    - name: Check file existence
+      id: check_files
+      uses: andstor/file-existence-action@v1
+      with:
+        files: "CNAME"
+    - name: If CNAME exists then copy CNAME to docs/
+      if: steps.check_files.outputs.files_exists == 'true'
       run: cp CNAME docs/
     - name: List files
       run: ls -lR

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Here are some shortcut scripts that have already been added in this repo:
 Scripts can be chained together like this:
 
 ``` js
-"clean": "rm -rf docs",
+"clean": "npx rimraf docs",
 "build": "npx @11ty/eleventy",
 "clean:build": "npm run clean && npm run build",
 "start": "npm run clean && npm run build && npm run serve"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "11ty-web-template",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "11ty-web-template",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "clean": "rm -rf docs",
+    "clean": "npx rimraf docs",
     "build": "npx @11ty/eleventy",
     "clean:build": "npm run clean && npm run build",
     "serve": "npx @11ty/eleventy --serve",


### PR DESCRIPTION
### Change Log
- Removes the linux only node command with cross platform `rimraf` command
