### PR TITLE
fix: wrong link to metro's `styles.css`

### DIFF
--- a/docs/_eleventy_redirect/index.html
+++ b/docs/_eleventy_redirect/index.html
@@ -1,4 +1,0 @@
-<!doctype html>
-  <meta http-equiv="refresh" content="0; url=/11ty-web-template/">
-  <title>Browsersync pathPrefix Redirect</title>
-  <a href="/11ty-web-template/">Go to /11ty-web-template/</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
 	<meta charset="UTF-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<link rel="stylesheet" href="https://lacmta.github.io/design-system/dist/css/uswds.min.css" type="text/css">
+	<link rel="stylesheet" href="https://lacmta.github.io/design-system/dist/css/styles.css" type="text/css">
 	<link rel="stylesheet" href="css/site.css" type="text/css">
 
 	<script src="https://lacmta.github.io/design-system/dist/js/uswds-init.min.js"></script>
@@ -35,7 +35,7 @@
 			desktop:grid-col-12
 			usa-prose usa-layout-docs
 		  " id="main-content">
-		  <h1>11ty Web Template</h1>
+		  <h1>11ty</h1>
 
 		  <p class="usa-intro">
 			Text here.
@@ -45,6 +45,7 @@
 	  </div>
 	</div>
   </div>
+
 	</main>
 
 	<script src="https://lacmta.github.io/design-system/dist/js/uswds.min.js"></script>

--- a/src/_includes/default.liquid
+++ b/src/_includes/default.liquid
@@ -10,7 +10,7 @@ js: site.js
 	<meta charset="UTF-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<link rel="stylesheet" href="https://lacmta.github.io/design-system/dist/css/uswds.min.css" type="text/css">
+	<link rel="stylesheet" href="https://lacmta.github.io/design-system/dist/css/styles.css" type="text/css">
 	<link rel="stylesheet" href="css/{{ css }}" type="text/css">
 
 	<script src="https://lacmta.github.io/design-system/dist/js/uswds-init.min.js"></script>


### PR DESCRIPTION
### Change log

URL should be 
https://lacmta.github.io/design-system/dist/css/styles.css

not 
`https://lacmta.github.io/design-system/dist/css/uswds.min.css`